### PR TITLE
Address service

### DIFF
--- a/Raktar.DataContext/DataTransferObjects/IAddressDTO.cs
+++ b/Raktar.DataContext/DataTransferObjects/IAddressDTO.cs
@@ -1,10 +1,15 @@
 ﻿namespace Raktar.DataContext.DataTransferObjects
 {
+    /// <summary>
+    /// Can be one of two states. <see cref="LandRegistryNumberDTO"/> or <see cref="SimpleAddressDTO"/>.
+    /// </summary>
     public interface IAddressDTO
     {
         public int AddressId { get; set; }
     }
-
+    /// <summary>
+    /// Can be one of two states. <see cref="LandRegistryNumberCreateDTO"/> or <see cref="SimpleAddressCreateDTO"/>.
+    /// </summary>
     public interface IAddressCreateDTO
     {
         public SettlementDTO Settlement { get; set; }

--- a/Raktar.DataContext/DataTransferObjects/LandRegistryNumberDTO.cs
+++ b/Raktar.DataContext/DataTransferObjects/LandRegistryNumberDTO.cs
@@ -2,13 +2,13 @@
 
 namespace Raktar.DataContext.DataTransferObjects
 {
-    class LandRegistryNumberDTO : IAddressDTO
+    public class LandRegistryNumberDTO : IAddressDTO
     {
         public int AddressId { get; set; }
         public SettlementDTO Settlement { get; set; }
         public string Contents { get; set; }
     }
-    class LandRegistryNumberCreateDTO : IAddressCreateDTO
+    public class LandRegistryNumberCreateDTO : IAddressCreateDTO
     {
         [Required]
         public SettlementDTO Settlement { get; set; }

--- a/Raktar.Services/AddressService.cs
+++ b/Raktar.Services/AddressService.cs
@@ -1,0 +1,79 @@
+﻿using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Raktar.DataContext;
+using Raktar.DataContext.DataTransferObjects;
+using Raktar.DataContext.Entities;
+using Raktar.Services;
+
+namespace Raktar.Services
+{
+    public interface IAddressService
+    {
+        /// <summary>
+        /// Returns an interface that can be one of two types. Use pattern matching (<see langword="is"/> keyword) to determine which.
+        /// <para><seealso href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/patterns"/></para>
+        /// </summary>
+        /// <returns>Either a <see cref="LandRegistryNumberDTO"/> or <see cref="SimpleAddressDTO"/>.</returns>
+        public Task<IAddressDTO> GetAddressAsync(int addressId);
+        /// <summary>
+        /// Returns an interface that can be one of two types. Use pattern matching (<see langword="is"/> keyword) to determine which.
+        /// <para><seealso href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/patterns"/></para>
+        /// </summary>
+        /// <returns>Either a <see cref="LandRegistryNumberDTO"/> or <see cref="SimpleAddressDTO"/>.</returns>
+        public Task<IAddressDTO> CreateAddressAsync(IAddressCreateDTO createDTO);
+    }
+    public class AddressService(WarehouseDbContext context, IMapper mapper, ILogger<IAddressService> logger) : IAddressService
+    {
+        private readonly WarehouseDbContext _context = context;
+        private readonly IMapper _mapper = mapper;
+        private readonly ILogger _logger = logger;
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentException"></exception>
+        public async Task<IAddressDTO> CreateAddressAsync(IAddressCreateDTO createDTO)
+        {
+            ArgumentNullException.ThrowIfNull(createDTO);
+
+            Address address = new();
+            await _context.Addresses.AddAsync(address);
+
+            switch (createDTO)
+            {
+                case SimpleAddressDTO dto:
+                    SimpleAddress sa = _mapper.Map<SimpleAddress>(dto);
+                    await _context.SimpleAddresses.AddAsync(sa);
+                    if (_logger.IsEnabled(LogLevel.Debug))
+                        _logger.LogDebug("Created address was a simple address.");
+                    break;
+                case LandRegistryNumberCreateDTO dto:
+                    LandRegistryNumber lrn = _mapper.Map<LandRegistryNumber>(dto);
+                    await _context.LandRegistryNumbers.AddAsync(lrn);
+                    if (_logger.IsEnabled(LogLevel.Debug))
+                        _logger.LogDebug("Created address was a land registry number.");
+                    break;
+                default:
+                    throw new ArgumentException("Unexpected address type. Cannot create.");
+            }
+
+            await _context.SaveChangesAsync();
+            return _mapper.Map<IAddressDTO>(address);
+        }
+        /// <exception cref="InvalidOperationException"></exception>
+        public async Task<IAddressDTO> GetAddressAsync(int addressId)
+        {
+            // Bad solution. Should make address entities with proper inheritance.
+            dynamic? tmp = null;
+
+            tmp ??= await _context.LandRegistryNumbers.FindAsync(addressId);
+            tmp ??= await _context.SimpleAddresses.FindAsync(addressId);
+            
+            IAddressDTO r = tmp switch
+            {
+                SimpleAddress simple => _mapper.Map<SimpleAddressDTO>(simple),
+                LandRegistryNumber registryNumber => _mapper.Map<LandRegistryNumberDTO>(registryNumber),
+                _ => throw new InvalidOperationException($"No address exists with id #{addressId}"),
+            };
+            return r;
+        }
+    }
+}

--- a/Raktar.Services/AutoMapperProfile.cs
+++ b/Raktar.Services/AutoMapperProfile.cs
@@ -11,8 +11,10 @@ namespace Raktar.Services
             CreateMap<User, UserDTO>().ReverseMap();
             CreateMap<UserRegisterDTO, User>();
             CreateMap<UserUpdateDTO, User>();
-            CreateMap<Address, IAddressDTO>().ReverseMap();
 
+            CreateMap<Address, IAddressDTO>().ReverseMap();
+            CreateMap<SimpleAddress, SimpleAddressDTO>().ReverseMap();
+            CreateMap<LandRegistryNumber, LandRegistryNumberDTO>().ReverseMap();
         }
     }
 }

--- a/Raktar/Program.cs
+++ b/Raktar/Program.cs
@@ -4,6 +4,9 @@ using Raktar.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
+builder.Logging.ClearProviders();
+builder.Logging.AddConsole();
+
 // Add services to the container.
 
 builder.Services.AddControllers();
@@ -14,6 +17,8 @@ builder.Services.AddDbContext<WarehouseDbContext>(options =>
 {
     options.UseSqlServer("Server=localhost;Database=WarehouseDB;Trusted_Connection=True;TrustServerCertificate=True;");
 });
+
+builder.Services.AddScoped<IAddressService, AddressService>();
 
 builder.Services.AddAutoMapper(typeof(AutoMapperProfile));
 


### PR DESCRIPTION
## Address service
- Created address service.
   - `GetAddressAsync(addressId)` Gets and address with the corresponding type DTO. Example:
```
try
{
    IAddressDTO address = await _addressService.GetAddressAsync(id);
    switch (address)
    {
        case LandRegistryNumberDTO dto:
            // Do something with dto...
            break;
        case SimpleAddressDTO dto:
            // Do something with dto...
            break;
    }
}
catch (InvalidOperationException)
{
    // No address found...
}
```
   - `CreateAddressAsync(createDTO)`. Expects an `IAddressCreateDTO` which can be either an instance of LandRegistryCreateDTO or SimpleAddressDTO. Example:
```
var createdAddress = await _addressService.CreateAddressAsync(landRegistryCreateDTO);
```
- Added necessary scope to main.
- Clarified DTO's with comments.
- Added logger service to main.